### PR TITLE
add travis branch permissions so it would only build master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,19 @@ addons:
     - libatlas-base-dev
     - liblapack-dev
 
+# blocklist
+# Block all /*feature*/ branches
+# Anything within /_>/ is treated as a Regex
+branches:
+  except:
+  - /*feature*/
+
+# safelist
+# Only Build and Test changes of the master branch
+branches:
+  only:
+  - master
+
 before_install:
  - travis_retry wget http://repo.continuum.io/miniconda/Miniconda-3.8.3-Linux-x86_64.sh -O miniconda.sh
  - chmod +x miniconda.sh


### PR DESCRIPTION
	This may not be very useful for now
	However, if the git branch permission is setup for github
	This should simplify the workflow without the use of fork

	Example a branch not getting built:
		feature/jz_travis_branch_config