### PR TITLE
Large changes to optimisation.py

### DIFF
--- a/equadratures/optimisation.py
+++ b/equadratures/optimisation.py
@@ -292,7 +292,7 @@ class Optimisation:
     def _calculate_subspace(self, S, f):
         parameters = [Parameter(distribution='uniform', lower=np.min(S[:,i]), upper=np.max(S[:,i]), order=1) for i in range(0, self.n)]
         self.poly = Poly(parameters, basis=Basis('total-order'), method='least-squares', \
-                     sampling_args={'mesh':'user-defined', 'sample-points': S, 'sample-outputs': f})
+                     sampling_args={'sample-points': S, 'sample-outputs': f})
         self.poly.set_model()
         self.Subs = Subspaces(full_space_poly=self.poly, method='active-subspace', subspace_dimension=self.d)
         if self.subspace_method == 'variable-projection':
@@ -837,7 +837,7 @@ class Optimisation:
         self.s_old = s_old
         self.f_old = self._blackbox_evaluation(self.s_old)
         self.del_k = del_k
-        
+
         self.d = d
         self.q = int(comb(self.d+2, 2))
         self.p = self.n + 1
@@ -856,6 +856,9 @@ class Optimisation:
         self._calculate_subspace(S_full, f_full)
         S_red, f_red = self._sample_set('new')
         for i in range(itermax):
+            # print(self.S.shape)
+            # print(np.unique(self.S, axis=0).shape)
+            # print(self.f)
             if len(self.f) >= max_evals or self.del_k < del_min:
                 break
             # print(self.f_old)

--- a/equadratures/subspaces.py
+++ b/equadratures/subspaces.py
@@ -41,7 +41,7 @@ class Subspaces(object):
         2. Seshadri, P., Shahpar, S., Constantine, P., Parks, G., Adams, M. (2018) Turbomachinery Active Subspace Performance Maps. Journal of Turbomachinery, 140(4), 041003. `Paper <http://turbomachinery.asmedigitalcollection.asme.org/article.aspx?articleid=2668256>`__.
         3. Hokanson, J., Constantine, P., (2018) Data-driven Polynomial Ridge Approximation Using Variable Projection. SIAM Journal of Scientific Computing, 40(3), A1566-A1589. `Paper <https://epubs.siam.org/doi/abs/10.1137/17M1117690>`__.
     """
-    def __init__(self, method, full_space_poly=None, sample_points=None, sample_outputs=None, polynomial_degree=2, subspace_dimension=2, bootstrap=False, subspace_init=None):
+    def __init__(self, method, full_space_poly=None, sample_points=None, sample_outputs=None, polynomial_degree=2, subspace_dimension=2, bootstrap=False, subspace_init=None, max_iter=1000):
         self.full_space_poly = full_space_poly
         self.sample_points = sample_points
         self.Y = None # for the zonotope vertices
@@ -67,7 +67,7 @@ class Subspaces(object):
             self.sample_outputs = self.full_space_poly.get_model_evaluations()
             self._get_active_subspace()
         elif self.method == 'variable-projection':
-            self._get_variable_projection(None,None,None,1000,subspace_init,False)
+            self._get_variable_projection(None,None,None,max_iter,subspace_init,False)
     def get_subspace_polynomial(self):
         """
         Returns a polynomial defined over the dimension reducing subspace.

--- a/tests/test_optimisation.py
+++ b/tests/test_optimisation.py
@@ -4,11 +4,16 @@ from unittest import TestCase
 import unittest
 import equadratures as eq
 
+import nlopt
+
+import warnings
+warnings.filterwarnings('ignore')
+
 class Test_optimisation(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        np.random.seed(42)
+        # np.random.seed(0)
         cls.degf = 4
         cls.degg1 = 1
         cls.degg2 = 3
@@ -61,7 +66,6 @@ class Test_optimisation(TestCase):
     def test_optimise_unconstrained_poly(self):
         n = 2
         N = 20
-
         X = np.random.uniform(-1.0, 1.0, (N, n))
         # Function values for f and Poly object
         f = self.ObjFun1(X)
@@ -89,7 +93,6 @@ class Test_optimisation(TestCase):
     def test_optimise_custom_function_linear_ineq_con1(self):
         n = 2
         N = 20
-
         X = np.random.uniform(-1.0, 1.0, (N, n))
         # Function values for f and Poly object
         f = self.ObjFun1(X)
@@ -109,7 +112,6 @@ class Test_optimisation(TestCase):
     def test_optimise_custom_function_linear_ineq_con2(self):
         n = 2
         N = 20
-
         X = np.random.uniform(-1.0, 1.0, (N, n))
         # Function values for f and Poly object
         f = self.ObjFun1(X)
@@ -282,9 +284,16 @@ class Test_optimisation(TestCase):
         Opt = eq.Optimisation(method='trust-region')
         Opt.add_objective(custom={'function': self.ObjFun1})
         x0 = np.zeros(n)
-        sol = Opt.optimise(x0)
-        if sol['status'] == 0:
-            np.testing.assert_almost_equal(sol['x'].flatten(), np.ones(n), decimal=3)
+        sol = Opt.optimise(x0, del_k=0.5)
+        np.testing.assert_almost_equal(sol['fun'], 0.0, decimal=6)
+
+    def test_optimise_trustregion_random(self):
+        n = 2
+        Opt = eq.Optimisation(method='trust-region')
+        Opt.add_objective(custom={'function': self.ObjFun1})
+        x0 = np.zeros(n)
+        sol = Opt.optimise(x0, del_k=0.5, random_initial=True)
+        np.testing.assert_almost_equal(sol['fun'], 0.0, decimal=6)
          
     def test_optimise_trustregion_bounds(self):
         n = 2
@@ -292,27 +301,24 @@ class Test_optimisation(TestCase):
         Opt.add_objective(custom={'function': self.ObjFun1})
         Opt.add_bounds(-np.ones(n), np.ones(n))
         x0 = np.zeros(n)
-        sol = Opt.optimise(x0)
-        if sol['status'] == 0:
-            np.testing.assert_almost_equal(sol['x'].flatten(), np.ones(n), decimal=3)
+        sol = Opt.optimise(x0, del_k=0.5)
+        np.testing.assert_almost_equal(sol['fun'], 0.0, decimal=6)
             
     def test_optimise_omorf_vp(self):
         n = 10
         Opt = eq.Optimisation(method='omorf')
         Opt.add_objective(custom={'function': self.ObjFun2})
         x0 = -2*np.ones(n)
-        sol = Opt.optimise(x0, max_evals=2000)
-        if sol['status'] == 0:
-            np.testing.assert_almost_equal(sol['x'].flatten(), -2.90353*np.ones(n), decimal=3)
+        sol = Opt.optimise(x0, del_k=0.5)
+        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=3)
             
     def test_optimise_omorf_as(self):
         n = 10
         Opt = eq.Optimisation(method='omorf')
         Opt.add_objective(custom={'function': self.ObjFun2})
         x0 = -2*np.ones(n)
-        sol = Opt.optimise(x0, max_evals=2000, subspace_method='active-subspaces')
-        if sol['status'] == 0:
-            np.testing.assert_almost_equal(sol['x'].flatten(), -2.90353*np.ones(n), decimal=3)
+        sol = Opt.optimise(x0, del_k=0.5, subspace_method='active-subspaces')
+        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=3)
             
     def test_optimise_omorf_bounds(self):
         n = 10
@@ -320,9 +326,8 @@ class Test_optimisation(TestCase):
         Opt.add_objective(custom={'function': self.ObjFun2})
         Opt.add_bounds(-5.12*np.ones(n), 5.12*np.ones(n))
         x0 = -2*np.ones(n)
-        sol = Opt.optimise(x0, max_evals=2000)
-        if sol['status'] == 0:
-            np.testing.assert_almost_equal(sol['x'].flatten(), -2.90353*np.ones(n), decimal=3)
+        sol = Opt.optimise(x0, del_k=0.5)
+        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_optimisation.py
+++ b/tests/test_optimisation.py
@@ -284,7 +284,7 @@ class Test_optimisation(TestCase):
         x0 = np.zeros(n)
         sol = Opt.optimise(x0)
         if sol['status'] == 0:
-            np.testing.assert_almost_equal(sol['x'].flatten(), np.array([1.0, 1.0]), decimal=3)
+            np.testing.assert_almost_equal(sol['x'].flatten(), np.ones(n), decimal=3)
          
     def test_optimise_trustregion_bounds(self):
         n = 2
@@ -294,7 +294,7 @@ class Test_optimisation(TestCase):
         x0 = np.zeros(n)
         sol = Opt.optimise(x0)
         if sol['status'] == 0:
-            np.testing.assert_almost_equal(sol['x'].flatten(), np.array([1.0, 1.0]), decimal=3)
+            np.testing.assert_almost_equal(sol['x'].flatten(), np.ones(n), decimal=3)
             
     def test_optimise_omorf_vp(self):
         n = 10

--- a/tests/test_optimisation.py
+++ b/tests/test_optimisation.py
@@ -13,7 +13,7 @@ class Test_optimisation(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # np.random.seed(0)
+        np.random.seed(0)
         cls.degf = 4
         cls.degg1 = 1
         cls.degg2 = 3
@@ -310,7 +310,7 @@ class Test_optimisation(TestCase):
         Opt.add_objective(custom={'function': self.ObjFun2})
         x0 = -2*np.ones(n)
         sol = Opt.optimise(x0, del_k=0.5)
-        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=3)
+        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=4)
             
     def test_optimise_omorf_as(self):
         n = 10
@@ -318,7 +318,7 @@ class Test_optimisation(TestCase):
         Opt.add_objective(custom={'function': self.ObjFun2})
         x0 = -2*np.ones(n)
         sol = Opt.optimise(x0, del_k=0.5, subspace_method='active-subspaces')
-        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=3)
+        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=4)
             
     def test_optimise_omorf_bounds(self):
         n = 10
@@ -327,7 +327,7 @@ class Test_optimisation(TestCase):
         Opt.add_bounds(-5.12*np.ones(n), 5.12*np.ones(n))
         x0 = -2*np.ones(n)
         sol = Opt.optimise(x0, del_k=0.5)
-        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=3)
+        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=4)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_optimisation.py
+++ b/tests/test_optimisation.py
@@ -284,7 +284,8 @@ class Test_optimisation(TestCase):
         Opt = eq.Optimisation(method='trust-region')
         Opt.add_objective(custom={'function': self.ObjFun1})
         x0 = np.zeros(n)
-        sol = Opt.optimise(x0, del_k=0.5)
+        sol = Opt.optimise(x0)
+        # print(sol)
         np.testing.assert_almost_equal(sol['fun'], 0.0, decimal=6)
 
     def test_optimise_trustregion_random(self):
@@ -292,7 +293,8 @@ class Test_optimisation(TestCase):
         Opt = eq.Optimisation(method='trust-region')
         Opt.add_objective(custom={'function': self.ObjFun1})
         x0 = np.zeros(n)
-        sol = Opt.optimise(x0, del_k=0.5, random_initial=True)
+        sol = Opt.optimise(x0, random_initial=True)
+        # print(sol)
         np.testing.assert_almost_equal(sol['fun'], 0.0, decimal=6)
          
     def test_optimise_trustregion_bounds(self):
@@ -301,7 +303,8 @@ class Test_optimisation(TestCase):
         Opt.add_objective(custom={'function': self.ObjFun1})
         Opt.add_bounds(-np.ones(n), np.ones(n))
         x0 = np.zeros(n)
-        sol = Opt.optimise(x0, del_k=0.5)
+        sol = Opt.optimise(x0)
+        # print(sol)
         np.testing.assert_almost_equal(sol['fun'], 0.0, decimal=6)
             
     def test_optimise_omorf_vp(self):
@@ -309,16 +312,18 @@ class Test_optimisation(TestCase):
         Opt = eq.Optimisation(method='omorf')
         Opt.add_objective(custom={'function': self.ObjFun2})
         x0 = -2*np.ones(n)
-        sol = Opt.optimise(x0, del_k=0.5)
-        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=4)
+        sol = Opt.optimise(x0)
+        # print(sol)
+        np.testing.assert_almost_equal(sol['fun'], -39.1661656*n, decimal=6)
             
     def test_optimise_omorf_as(self):
         n = 10
         Opt = eq.Optimisation(method='omorf')
         Opt.add_objective(custom={'function': self.ObjFun2})
         x0 = -2*np.ones(n)
-        sol = Opt.optimise(x0, del_k=0.5, subspace_method='active-subspaces')
-        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=4)
+        sol = Opt.optimise(x0, subspace_method='active-subspaces')
+        # print(sol)
+        np.testing.assert_almost_equal(sol['fun'], -39.1661656*n, decimal=6)
             
     def test_optimise_omorf_bounds(self):
         n = 10
@@ -326,8 +331,9 @@ class Test_optimisation(TestCase):
         Opt.add_objective(custom={'function': self.ObjFun2})
         Opt.add_bounds(-5.12*np.ones(n), 5.12*np.ones(n))
         x0 = -2*np.ones(n)
-        sol = Opt.optimise(x0, del_k=0.5)
-        np.testing.assert_almost_equal(sol['fun'], -39.166165*n, decimal=4)
+        sol = Opt.optimise(x0)
+        # print(sol)
+        np.testing.assert_almost_equal(sol['fun'], -39.1661656*n, decimal=6)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_optimisation.py
+++ b/tests/test_optimisation.py
@@ -4,8 +4,6 @@ from unittest import TestCase
 import unittest
 import equadratures as eq
 
-import nlopt
-
 import warnings
 warnings.filterwarnings('ignore')
 


### PR DESCRIPTION
Many changes for 'trust-region' and 'omorf' methods, including:

- method of generating initial set using coordinate vectors and random points (borrowed from PYBOBYQA)

- OMoRF now manages two separate sets, one for linear interpolation of the full space and one for quadratic interpolation in the reduced space (helps make sure it doesn't converge to suboptimal solutions)

- trust-region management of OMoRF e.g. only reduce trust-region radius when linear model used for subspaces is 'well-poised'

- Minor changes in default algorithmic parameters as well as some syntax changes

- Added scaling for bounded problems

If there are any questions, please ask James.

