### PR TITLE
Fixed 2 small typos in the tutorial docs

### DIFF
--- a/source/_documentation/tutorial_1.txt
+++ b/source/_documentation/tutorial_1.txt
@@ -18,7 +18,7 @@ We now demonstrate some basic functionality of this parameter. First consider th
 
 	from equadratures import *
 	import numpy as np
-        Import matplotlib.pyplot as plt
+    import matplotlib.pyplot as plt
 
 	s = Parameter(distribution='normal', shape_parameter_A = 0.0, shape_parameter_B = 1.0, order=3)
 

--- a/source/_documentation/tutorial_2.txt
+++ b/source/_documentation/tutorial_2.txt
@@ -7,7 +7,7 @@ Consider the task of integrating the function
 
 .. math::
 
-	I = \int_{-1}^{-1} f\left( s \right) \rho \left( s \right) ds
+	I = \int_{-1}^{1} f\left( s \right) \rho \left( s \right) ds
 
 where the measure :math:`\rho \left( s \right)` is the uniform distribution over :math:`[-1,1]`. Our task is to numerically approximate this integral using a quadrature rule, i.e.,
 


### PR DESCRIPTION
Fixed two small typos:

- Replaced an 'Import' with 'import' in a code example in tutorial 1

- Fixed the bounds of an integral in latex from {-1}{-1} to {-1}{1} in tutorial 2