### PR TITLE
Fix #285: Incorrect axis dimension on boolean mask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ nosetests.xml
 *.mo
 .eggs
 
+# Test outputs
+effective-quadratures-output.txt
+piston_model.txt
+

--- a/equadratures/basis.py
+++ b/equadratures/basis.py
@@ -305,7 +305,7 @@ def total_order_basis(orders):
         total_order = np.vstack((total_order, R))
     
     # Now, as we expect the order to be 
-    total_order = total_order[np.sum(total_order, axis=0) <= highest_order]
+    total_order = total_order[np.sum(total_order, axis=1) <= highest_order]
     return total_order
 
 def sparse_grid_basis(level, growth_rule, dimensions):

--- a/equadratures/sampling_methods/induced.py
+++ b/equadratures/sampling_methods/induced.py
@@ -63,8 +63,8 @@ class Induced(Sampling):
         # TODO add a total order index set with random samples
         # The above would be necessary in higher dimensions
         # Randomly sample index-set for each quadrature point
-        print('_set_points')
-        print(ray_imported)
+        #print('_set_points')
+        #print(ray_imported)
         if ray_imported:
             ray.init()
         else:
@@ -89,7 +89,7 @@ class Induced(Sampling):
                 max_order
                 )
         #print(quadrature_points)
-        print('done!')
+        #print('done!')
         if ray_imported:
             ray.shutdown()
         else:
@@ -135,8 +135,8 @@ class Induced(Sampling):
                     parameter,
                     sampled_cdf_values,
                     order)
-            print('i am here!')
-            print(ray_imported)
+            #print('i am here!')
+            #print(ray_imported)
             if ray_imported:
                 inverse_cdf_values = ray.get(inverse_cdf_values)
                 quadrature_points[variable_positions] = inverse_cdf_values


### PR DESCRIPTION
Does the following:
- Fix boolean mask axis in generating total_order (please verify).
- Add test artifacts to `.gitignore`.
- Disable some print statements in test run.